### PR TITLE
issues/#10 tweet and comment web push create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 # .gitignore
 # .DS_Store banished!
 .DS_Store
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,12 @@ gem 'carrierwave'
 
 gem 'rmagick'
 
+gem 'pusher'
+
+gem 'dotenv-rails'
+
+gem 'font-awesome-sass'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,12 +62,23 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     devise-i18n (1.2.0)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.6.1)
     erubis (2.7.0)
     execjs (2.7.0)
     faker (1.1.2)
       i18n (~> 0.5)
+    font-awesome-sass (4.7.0)
+      sass (>= 3.2)
+    gon (6.2.0)
+      actionpack (>= 3.0)
+      multi_json
+      request_store (>= 1.0)
     hike (1.2.3)
+    httpclient (2.8.3)
     i18n (0.8.6)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
@@ -102,6 +113,11 @@ GEM
       byebug (~> 9.0)
       pry (~> 0.10)
     public_suffix (2.0.5)
+    pusher (1.3.1)
+      httpclient (~> 2.7)
+      multi_json (~> 1.0)
+      pusher-signature (~> 0.1.8)
+    pusher-signature (0.1.8)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -126,6 +142,7 @@ GEM
       i18n
       polyamorous (~> 1.3)
     rdoc (4.3.0)
+    request_store (1.3.2)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     rmagick (2.16.0)
@@ -178,13 +195,17 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   devise
   devise-i18n
+  dotenv-rails
   faker (= 1.1.2)
+  font-awesome-sass
+  gon
   jbuilder (~> 1.2)
   jquery-rails
   letter_opener
   momentjs-rails (>= 2.9.0)
   pg
   pry-byebug
+  pusher
   rails (= 4.0.5)
   ransack
   rmagick

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,7 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "font-awesome-sprockets";
+@import "font-awesome";
 @import 'bootstrap-datetimepicker';
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
+  before_action :current_notifications, if: :signed_in?
+
+  def current_notifications
+    @notifications_count = Notification.where(user_id: current_user.id).where(read: false).count
+  end
+
   def after_sign_in_path_for(resource)
     if cookies[:auth_token]
       home_path

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,24 @@
+class CommentsController < ApplicationController
+  def new
+    @comment = Comment.new
+    @tweet = Tweet.find_by(id: params['id'])
+    @user = current_user
+    @to_user = @tweet.user
+  end
+  def create
+    respond_to do |format|
+      if @comment = Comment.create(comment_params)
+        @notification = @comment.notifications.create(user_id: @comment.to_user_id, tweet_id: @comment.tweet_id)
+        Pusher.trigger("user_#{@comment.to_user_id}_channel", 'comment_created', { message: 'あなたの作成したブログにコメントが付きました' })
+        format.html { redirect_to home_url, flash:{success: 'Tweetのコメントを作成しました'} }
+      else
+        format.html { redirect_to home_url, flash:{error: 'Tweetのコメントに失敗しました'} }
+      end
+    end
+
+  end
+  private
+  def comment_params
+      params.require(:comment).permit(:comment,:user_id,:tweet_id,:to_user_id)
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,6 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @notifications = Notification.where(user_id: current_user.id).where(read: false).order(created_at: :desc)
+  end
+end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -3,12 +3,23 @@ class TweetsController < ApplicationController
   before_action :correct_user,   only: [:destroy,:edit,:update]
   def create
     @tweet = current_user.tweets.build(tweet_params)
+    @notification = @tweet.notifications.build(user_id: @tweet.user.id )
     if @tweet.save
+      Pusher.trigger("user_#{@tweet.user_id}_channel", 'comment_created', { message: 'あなたの作成したブログにコメントが付きました' })
       flash[:success] = "Tweetを作成しました"
-      redirect_to root_url
+      redirect_to home_url
     else
       flash[:error] = "Tweetの作成に失敗しました"
       redirect_to root_url
+    end
+  end
+
+  def show
+    if params[:notification_id]
+      @notification = Notification.find(params[:notification_id])
+      @notification.update(read: true)
+      @tweet = Tweet.find_by(id: params[:id])
+      @comments = Comment.where(tweet_id:@tweet.id).limit(10)
     end
   end
 

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,5 @@
+module NotificationsHelper
+  def posted_time(time)
+    time > Date.today ? "#{time_ago_in_words(time)}" : time.strftime('%m月%d日')
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ActiveRecord::Base
+  belongs_to :user
+  has_many :notifications, dependent: :destroy
+  default_scope -> { order('created_at DESC') }
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,5 @@
+class Notification < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :tweet
+  belongs_to :comment
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,6 +1,7 @@
 class Tweet < ActiveRecord::Base
   belongs_to :user
   default_scope -> { order('created_at DESC') }
+  has_many :notifications, dependent: :destroy
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 140 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   has_many :tweets, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :relationships, foreign_key: "follower_id", dependent: :destroy
   has_many :followed_users, through: :relationships, source: :followed
   has_many :reverse_relationships, foreign_key: "followed_id",

--- a/app/views/comments/_comment_modal.html.erb
+++ b/app/views/comments/_comment_modal.html.erb
@@ -1,0 +1,26 @@
+<div class="modal-dialog">
+  <div class="modal-content">
+    <%= form_for(@comment, remote: true) do |f| %>
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">Tweetのコメント</h4>
+      </div>
+      <div class="modal-body">
+        <div class="field">
+          <%= f.label :comment, "コメント内容" %><br>
+          <%= f.text_field :comment, size: 80  %>
+        </div>
+      </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+          <%= f.hidden_field :user_id, :value =>  @user.id %>
+          <%= f.hidden_field :tweet_id, :value =>  @tweet.id %>
+          <%= f.hidden_field :to_user_id, :value =>  @to_user.id %>
+          <%= f.submit "作成する", :class => "btn btn-primary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/_new.html.erb
+++ b/app/views/comments/_new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'comment_modal' %>

--- a/app/views/comments/new.js.erb
+++ b/app/views/comments/new.js.erb
@@ -1,0 +1,3 @@
+$("#tweet-comment-modal").html("<%= escape_javascript(render 'new') %>")
+
+$("#tweet-comment-modal").modal("show")

--- a/app/views/home/_tweet_show.html.erb
+++ b/app/views/home/_tweet_show.html.erb
@@ -13,7 +13,10 @@
         <%= link_to "削除", tweet, method: :delete,
                                          data: { confirm: "Tweetを削除してもよろしいでしょうか？" },
                                          title: tweet.content %>
+      <% else %>
+        <%= link_to 'コメント',new_comment_path(id: tweet.id), remote: true %>
       <% end %>
+      <div id="tweet-comment-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
       <div id="tweet-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
     </li>
   </ol>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,6 +4,11 @@
        <ul class="nav navbar-nav navbar-left">
          <li><%= link_to "ホーム",    home_path %></li>
          <li><%= link_to "設定",    edit_user_registration_path %></li>
+         <li>
+           <%= link_to notifications_index_path do %>
+            <i class="fa fa-bell"><%= @notifications_count %></i>
+          <% end %>
+         </li>
          <li><%= link_to "ログアウト", destroy_user_session_path, method: "delete" %></li>
        </ul>
      </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,19 @@
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "validator", "data-turbolinks-track" => true %>
 
+  <% if user_signed_in? %>
+  <script src="https://js.pusher.com/4.1/pusher.min.js"></script>
+
+  <script>
+
+  var pusher = new Pusher('<%= ENV["PUSHER_KEY"] %>',{ encrypted: true, cluster: 'ap1' });
+
+  var channel = pusher.subscribe("user_<%= current_user.id %>_channel");
+
+  channel.bind('comment_created', function(data) { alert(data.message); });
+
+  </script>
+  <% end %>
   <%= csrf_meta_tags %>
   <!--[if lt IE 9]>
     <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,21 @@
+<h2>お知らせ</h2>
+<ul>
+  <% @notifications.each do |notification| %>
+  <hr>
+    <li>
+      <p>
+        <% if notification.comment_id.present? %>
+          <%= notification.comment.user.try(:name) %>さんが<%= notification.tweet.user.try(:name) %>さんの
+          <%= link_to "#{notification.tweet.content}", tweets_show_path(id: notification.tweet.id, notification_id: notification.id) %>に対するコメントをしました。
+        <% else %>
+          <%= notification.tweet.user.try(:name) %>さんが
+          <%= link_to "#{notification.tweet.content}", tweets_show_path(id: notification.tweet.id, notification_id: notification.id) %>をツイートしました。
+        <% end %>
+      </p>
+      <p><%= posted_time(notification.created_at) %></p>
+    </li>
+  <% end %>
+  <% if @notifications.blank?%>
+    <li>現在、表示するものはありません。</li>
+  <% end %>
+</ul>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,0 +1,21 @@
+<h2>ツイート詳細</h2>
+<ol class="tweets">
+  <li>
+    <span class="small">Tweet_User_Name: <%= @tweet.user.name %></span>
+    <span class="content">Tweet_Content:<%= @tweet.content %></span>
+    <span class="timestamp">
+      Tweet_Time:<%= time_ago_in_words(@tweet.created_at) %>前
+    </span>
+    <ol class="tweets">
+    <% @comments.each do |comment| %>
+    <li>
+      <span class="small">Comment_User_Name: <%= comment.user.name %></span>
+      <span class="content">Comment:<%= comment.comment %></span>
+      <span class="timestamp">
+        Comment_Time:<%= time_ago_in_words(comment.created_at) %>前
+      </span>
+    </li>
+    <% end %>
+    </ol>
+  </li>
+</ol>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,10 +78,15 @@ TwitterCloneapp::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.action_mailer.default_url_options = { host: 'blooming-plateau-46522.herokuapp.com' } ActionMailer::Base.delivery_method = :smtp ß
-  ActionMailer::Base.smtp_settings = { user_name: ENV['SENDGRID_USERNAME'],
-     password: ENV['SENDGRID_PASSWORD'], domain: "heroku.com",
-    address: "smtp.sendgrid.net", port: 587,
-    authentication: :plain, enable_starttls_auto: true
+  config.action_mailer.default_url_options = { host: 'blooming-plateau-46522.herokuapp.com' }
+  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: "heroku.com",
+    address: "smtp.sendgrid.net",
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 end

--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -1,0 +1,12 @@
+require 'pusher'
+
+Pusher.app_id = ENV["PUSHER_APP_ID"]
+
+Pusher.key = ENV["PUSHER_KEY"]
+
+Pusher.secret = ENV["PUSHER_SECRET"]
+
+Pusher.cluster = 'ap1'
+
+Pusher.logger = Rails.logger
+Pusher.encrypted = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 TwitterCloneapp::Application.routes.draw do
+  get "notifications/index"
   devise_for :users, :controllers => {
     :registrations => "registrations",
     :sessions => "sessions"
@@ -8,10 +9,13 @@ TwitterCloneapp::Application.routes.draw do
   end
   match '/home/',    to: 'home#index',    via: 'get'
   match '/edit',    to: 'home#edit',    via: 'get'
+  match '/comment',    to: 'tweets#comment',    via: 'get'
   match '/users/' => 'users#index', :via => 'get'
   match '/users/show' => 'users#show', :via => 'get'
+  match '/tweets/show' => 'tweets#show', :via => 'get'
   resources :tweets, only:[:create, :destroy,:edit,:update]
   resources :relationships, only: [:create, :destroy]
+  resources :comments, only:[:new,:create, :destroy,:edit,:update]
   resources :users, only: [:show, :index, :destroy] do
     member do
       get :following, :followers

--- a/db/migrate/20171014114900_create_notifications.rb
+++ b/db/migrate/20171014114900_create_notifications.rb
@@ -1,0 +1,11 @@
+class CreateNotifications < ActiveRecord::Migration
+  def change
+    create_table :notifications do |t|
+      t.boolean :read, default: false
+      t.references :user, index: true
+      t.references :tweet, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171015012156_create_comments.rb
+++ b/db/migrate/20171015012156_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.integer :tweet_id
+      t.integer :user_id
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171016071343_add_comment_id_to_notification.rb
+++ b/db/migrate/20171016071343_add_comment_id_to_notification.rb
@@ -1,0 +1,5 @@
+class AddCommentIdToNotification < ActiveRecord::Migration
+  def change
+    add_column :notifications, :comment_id, :integer
+  end
+end

--- a/db/migrate/20171017211127_add_to_user_to_comment.rb
+++ b/db/migrate/20171017211127_add_to_user_to_comment.rb
@@ -1,0 +1,5 @@
+class AddToUserToComment < ActiveRecord::Migration
+  def change
+    add_column :comments, :to_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171007114517) do
+ActiveRecord::Schema.define(version: 20171017211127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: true do |t|
+    t.integer  "tweet_id"
+    t.integer  "user_id"
+    t.string   "comment"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "to_user_id"
+  end
+
+  create_table "notifications", force: true do |t|
+    t.boolean  "read",       default: false
+    t.integer  "user_id"
+    t.integer  "tweet_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "comment_id"
+  end
+
+  add_index "notifications", ["tweet_id"], name: "index_notifications_on_tweet_id", using: :btree
+  add_index "notifications", ["user_id"], name: "index_notifications_on_user_id", using: :btree
 
   create_table "relationships", force: true do |t|
     t.integer  "follower_id"
@@ -66,5 +87,14 @@ ActiveRecord::Schema.define(version: 20171007114517) do
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+
+  create_table "web_pushes", force: true do |t|
+    t.integer  "user_id"
+    t.string   "endpoint"
+    t.string   "p256dh"
+    t.string   "auth"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class NotificationsControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  tweet_id: MyString
+  : 1
+  user_id: MyString
+  : 1
+  comment: MyString
+  : MyString
+
+two:
+  tweet_id: MyString
+  : 1
+  user_id: MyString
+  : 1
+  comment: MyString
+  : MyString

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  read: false
+  user_id: 
+  tweet_id: 
+
+two:
+  read: false
+  user_id: 
+  tweet_id: 

--- a/test/helpers/comments_helper_test.rb
+++ b/test/helpers/comments_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class CommentsHelperTest < ActionView::TestCase
+end

--- a/test/helpers/notifications_helper_test.rb
+++ b/test/helpers/notifications_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class NotificationsHelperTest < ActionView::TestCase
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・テスト確認用にツイート作成時に自分宛にプッシュ通知を送れるようにしています。
・またツイート作成者以外でツイートに対するコメントがHOME画面のツイート一覧からできるようにし、コメント作成後ツイート作成者に通知が送れるように機能を実装。
・お知らせ画面では、プッシュ通知の内容を確認できる。そこからツイートの詳細画面に遷移できるようにしました。
（※お知らせ画面はベルのマークから遷移可能）
・ツイート詳細画面では、ツイートとそのツイートに紐づくコメントを最新順に表示
（※コメントは１０件まで表示）
